### PR TITLE
Return NOT supported for WRITESAME scsi command until we support it completely

### DIFF
--- a/usr/bs_hyc.c
+++ b/usr/bs_hyc.c
@@ -57,7 +57,7 @@ io_type_t scsi_cmd_operation(struct scsi_cmd *cmdp)
 			op = UNKNOWN;
 			goto out;
 		}
-		op = WRITE_SAME_OP;
+		op = UNKNOWN;
 		break;
 	case SYNCHRONIZE_CACHE:
 	case SYNCHRONIZE_CACHE_16:


### PR DESCRIPTION
This is to allow running mkfs.ext4 test which is first trying to use WERITESAME for formatting of disk and in case of failure, fall back on sending  the format request for each block separately.