### PR TITLE
[DP-2090] Modify TGT default behavior to pass abort commands down

### DIFF
--- a/usr/bs_hyc.c
+++ b/usr/bs_hyc.c
@@ -253,7 +253,9 @@ static void bs_hyc_handle_completion(int fd, int events, void *datap)
 		/* Process completed request commands */
 		for (uint32_t i = 0; i < nr_results; ++i) {
 			struct scsi_cmd *cmdp = (struct scsi_cmd *) resultsp[i].privatep;
-			assert(cmdp);
+			if (cmdp == NULL) {
+				continue;
+			}
 			struct iscsi_connection* cp = scsi_cmd_to_iscsi_connection(cmdp);
 
 			if (connp == NULL) {

--- a/usr/bs_hyc.c
+++ b/usr/bs_hyc.c
@@ -125,8 +125,8 @@ static int bs_hyc_cmd_submit(struct scsi_cmd *cmdp)
 	struct scsi_lu     *lup = NULL;
 	struct bs_hyc_info *infop = NULL;
 	io_type_t           op;
-	size_t              length;
-	uint64_t            offset;
+	size_t              length = 0;
+	uint64_t            offset = 0;
 	char               *bufp = NULL;
 	RequestID           reqid = kInvalidRequestID;
 	int                 rc = 0;

--- a/usr/bs_hyc.c
+++ b/usr/bs_hyc.c
@@ -59,15 +59,12 @@ io_type_t scsi_cmd_operation(struct scsi_cmd *cmdp)
 	case WRITE_12:
 	case WRITE_16:
 		op = WRITE;
-		eprintf("\nWRITE cmd: %p op: %x\n", cmdp, scsi_op);
-
 		break;
 	case READ_6:
 	case READ_10:
 	case READ_12:
 	case READ_16:
 		op = READ;
-		eprintf("\nREAD cmd: %p op: %x\n", cmdp, scsi_op);
 		break;
 	case WRITE_SAME:
 	case WRITE_SAME_16:
@@ -77,7 +74,6 @@ io_type_t scsi_cmd_operation(struct scsi_cmd *cmdp)
 				" supported yet.\n");
 		}
 		op = WRITE_SAME_OP;
-		eprintf("\nWRITESAME cmd: %p op: %x\n", cmdp, scsi_op);
 		break;
 	case SYNCHRONIZE_CACHE:
 	case SYNCHRONIZE_CACHE_16:
@@ -153,16 +149,16 @@ static int bs_hyc_cmd_submit(struct scsi_cmd *cmdp)
 		length = scsi_cmd_length(cmdp);
 
 		/*
-	 	* Simply returing from top for zero size IOs, we may need to handle
-	 	* it later for the barrier IOs
-	 	*/
+		* Simply returing from top for zero size IOs, we may need to handle
+		* it later for the barrier IOs
+		*/
 
-		if(op == WRITE) {
+		if (op == WRITE) {
 			if (!length) {
 				eprintf("Zero size write IO, returning from top :%lu\n", length);
 				return 0;
 			}
-		} else if(op == READ) {
+		} else if (op == READ) {
 			if (!length) {
 				eprintf("Zero size read IO, returning from top :%lu\n", length);
 				return 0;
@@ -171,8 +167,6 @@ static int bs_hyc_cmd_submit(struct scsi_cmd *cmdp)
 
 		bufp = scsi_cmd_buffer(cmdp);
 		set_cmd_async(cmdp);
-	} else {
-		eprintf("\n### ABORT REQUEST RECEIVED");
 	}
 
 	switch (op) {

--- a/usr/bs_hyc.h
+++ b/usr/bs_hyc.h
@@ -9,6 +9,8 @@ typedef enum {
 	WRITE,
 	/* Appending with *_OP, since just WRITE_SAME conflicts with scsi.h */
 	WRITE_SAME_OP,
+	ABORT_TASK_OP,
+	ABORT_TASK_SET_OP,
 	UNKNOWN,
 } io_type_t;
 

--- a/usr/target.c
+++ b/usr/target.c
@@ -1321,6 +1321,7 @@ static int abort_cmd(struct target *target, struct mgmt_req *mreq,
 {
 	int err = 0;
 
+	eprintf("\nfound %" PRIx64 " %lx\n", cmd->tag, cmd->state);
 
 	if (cmd_processed(cmd)) {
 		/*
@@ -1330,13 +1331,15 @@ static int abort_cmd(struct target *target, struct mgmt_req *mreq,
 		 */
 
 		cmd->mreq = mreq;
-		eprintf("\n@@@In abort_cmd: cmd:%p %" PRIx64 " %lx\n", cmd, cmd->tag, cmd->state);
+		eprintf("\n%s: cmd:%p\n", __func__, cmd);
 		err = cmd->dev->cmd_perform(target->tid, cmd);
-	} else {
-		eprintf("\n@@@ In abort_cmd: Calling cmd_done %" PRIx64 " %lx\n", cmd->tag, cmd->state);
+	}
+
+	if (!err) {
 		cmd->dev->cmd_done(target, cmd);
 		target_cmd_io_done(cmd, TASK_ABORTED);
 	}
+
 	return err;
 }
 
@@ -1347,7 +1350,7 @@ static int abort_task_set(struct mgmt_req *mreq, struct target *target,
 	struct it_nexus *itn;
 	int err, count = 0;
 
-	eprintf("found %" PRIx64 " %d\n", tag, all);
+	eprintf("\nfound %" PRIx64 " %d\n", tag, all);
 
 	list_for_each_entry(itn, &target->it_nexus_list, nexus_siblings) {
 		list_for_each_entry_safe(cmd, tmp, &itn->cmd_list, c_hlist) {

--- a/usr/target.c
+++ b/usr/target.c
@@ -1163,7 +1163,6 @@ int target_cmd_perform(int tid, struct scsi_cmd *cmd)
 	enabled = cmd_enabled(q, cmd);
 	dprintf("%p %x %" PRIx64 " %d\n", cmd, cmd->scb[0], cmd->dev_id,
 		enabled);
-
 	if (enabled) {
 		result = scsi_cmd_perform(cmd->it_nexus->host_no, cmd);
 
@@ -1322,7 +1321,6 @@ static int abort_cmd(struct target *target, struct mgmt_req *mreq,
 {
 	int err = 0;
 
-	eprintf("found %" PRIx64 " %lx\n", cmd->tag, cmd->state);
 
 	if (cmd_processed(cmd)) {
 		/*
@@ -1332,8 +1330,10 @@ static int abort_cmd(struct target *target, struct mgmt_req *mreq,
 		 */
 
 		cmd->mreq = mreq;
-		err = -EBUSY;
+		eprintf("\n@@@In abort_cmd: cmd:%p %" PRIx64 " %lx\n", cmd, cmd->tag, cmd->state);
+		err = cmd->dev->cmd_perform(target->tid, cmd);
 	} else {
+		eprintf("\n@@@ In abort_cmd: Calling cmd_done %" PRIx64 " %lx\n", cmd->tag, cmd->state);
 		cmd->dev->cmd_done(target, cmd);
 		target_cmd_io_done(cmd, TASK_ABORTED);
 	}

--- a/usr/target.c
+++ b/usr/target.c
@@ -1335,11 +1335,6 @@ static int abort_cmd(struct target *target, struct mgmt_req *mreq,
 		err = cmd->dev->cmd_perform(target->tid, cmd);
 	}
 
-	if (!err) {
-		cmd->dev->cmd_done(target, cmd);
-		target_cmd_io_done(cmd, TASK_ABORTED);
-	}
-
 	return err;
 }
 


### PR DESCRIPTION
Modify TGT default behavior to pass abort commands down to thrift client

Signed-off-by: Vikram Jadhav <vikram.jadhav@primaryio.com>