### PR TITLE
Implemented DP-2123

### DIFF
--- a/usr/tgtd.c
+++ b/usr/tgtd.c
@@ -1227,7 +1227,6 @@ static int get_vmdk_stats(const _ha_request *reqp,
 	json_object_set_new(jobj, "rpc_requests_scheduled", json_integer(vmdk_stats.rpc_requests_scheduled));
 
 	char *post_data = json_dumps(jobj, JSON_ENCODE_ANY);
-	json_object_clear(jobj);
 	json_decref(jobj);
 
 	ha_set_response_body(resp, HTTP_STATUS_OK, post_data, strlen(post_data));

--- a/usr/tgtd.c
+++ b/usr/tgtd.c
@@ -1177,6 +1177,67 @@ static int lun_delete(const _ha_request *reqp,
 	return HA_CALLBACK_CONTINUE;
 }
 
+static int get_vmdk_stats(const _ha_request *reqp,
+	_ha_response *resp, void *userp)
+{
+	int rc = 0;
+	vmdk_stats_t vmdk_stats = {0};
+
+	const char* vmdkid = ha_parameter_get(reqp, "vmdkid");
+	if (vmdkid == NULL) {
+		set_err_msg(resp, TGT_ERR_INVALID_PARAM,
+			"vmdkid param is not given");
+		return HA_CALLBACK_CONTINUE;
+	}
+
+	if (disallow_rest_call()) {
+		set_err_msg(resp, TGT_ERR_HA_MAX_LIMIT,
+		"Too many pending requests at TGT. Retry after some time");
+		return HA_CALLBACK_CONTINUE;
+	}
+
+	pthread_mutex_lock(&ha_rest_mutex);
+
+	if (0 != (rc = HycGetVmdkStats(vmdkid, &vmdk_stats))) {
+		if (rc == -EINVAL) {
+			set_err_msg(resp, TGT_ERR_INVALID_VMDKID,
+			"vmdkid is not valid/exist");
+		}
+		goto out;
+	}
+
+	json_t *jobj = json_object();
+	json_object_set_new(jobj, "read_requests", json_integer(vmdk_stats.read_requests));
+	json_object_set_new(jobj, "read_failed", json_integer(vmdk_stats.read_failed));
+	json_object_set_new(jobj, "read_bytes", json_integer(vmdk_stats.read_bytes));
+	json_object_set_new(jobj, "read_latency", json_integer(vmdk_stats.read_latency));
+
+	json_object_set_new(jobj, "write_requests", json_integer(vmdk_stats.write_requests));
+	json_object_set_new(jobj, "write_failed", json_integer(vmdk_stats.write_failed));
+	json_object_set_new(jobj, "write_same_requests", json_integer(vmdk_stats.write_same_requests));
+	json_object_set_new(jobj, "write_same_failed", json_integer(vmdk_stats.write_same_failed));
+	json_object_set_new(jobj, "write_bytes", json_integer(vmdk_stats.write_bytes));
+	json_object_set_new(jobj, "write_latency", json_integer(vmdk_stats.write_latency));
+
+	json_object_set_new(jobj, "truncate_requests", json_integer(vmdk_stats.truncate_requests));
+	json_object_set_new(jobj, "truncate_failed", json_integer(vmdk_stats.truncate_failed));
+	json_object_set_new(jobj, "truncate_latency", json_integer(vmdk_stats.truncate_latency));
+
+	json_object_set_new(jobj, "pending", json_integer(vmdk_stats.pending));
+	json_object_set_new(jobj, "rpc_requests_scheduled", json_integer(vmdk_stats.rpc_requests_scheduled));
+
+	char *post_data = json_dumps(jobj, JSON_ENCODE_ANY);
+	json_object_clear(jobj);
+	json_decref(jobj);
+
+	ha_set_response_body(resp, HTTP_STATUS_OK, post_data, strlen(post_data));
+	free(post_data);
+
+out:
+	pthread_mutex_unlock(&ha_rest_mutex);
+	remove_rest_call();
+	return HA_CALLBACK_CONTINUE;
+}
 
 
 int tgt_ha_start_cb(const _ha_request *reqp,
@@ -1220,7 +1281,7 @@ int main(int argc, char **argv)
 	int is_daemon = 1, is_debug = 0;
 	int ret;
 	struct ha_handlers *ep_handlers = malloc(sizeof(struct ha_handlers) +
-		5 * sizeof(struct ha_endpoint_handlers));
+		6 * sizeof(struct ha_endpoint_handlers));
 	char *etcd_ip = NULL;
 	char *svc_label = NULL;
 	char *tgt_version = NULL;
@@ -1288,6 +1349,13 @@ int main(int argc, char **argv)
 	strncpy(ep_handlers->ha_endpoints[*ha_handler_idx].ha_url_endpoint, "lun_delete",
 		strlen("lun_delete") + 1);
 	ep_handlers->ha_endpoints[*ha_handler_idx].callback_function = lun_delete;
+	ep_handlers->ha_endpoints[*ha_handler_idx].ha_user_data = NULL;
+	ep_handlers->ha_count += 1;
+
+	ep_handlers->ha_endpoints[*ha_handler_idx].ha_http_method = GET;
+	strncpy(ep_handlers->ha_endpoints[*ha_handler_idx].ha_url_endpoint, "vmdk_stats",
+		strlen("vmdk_stats") + 1);
+	ep_handlers->ha_endpoints[*ha_handler_idx].callback_function = get_vmdk_stats;
 	ep_handlers->ha_endpoints[*ha_handler_idx].ha_user_data = NULL;
 	ep_handlers->ha_count += 1;
 


### PR DESCRIPTION
Added a new rest call 'vmdk_stats' to get the vmdk stats for a given vmdkid.

Example command to invoke a rest call:
curl -X GET "http://127.0.0.1:9001/tgt_svc/v1.0/vmdk_stats?vmdkid=1"

Test:
Tested a working functionality by invoking a curl command

Signed-off-by: Deepen Mehta <deepen.mehta@primaryio.com>