### PR TITLE
Change default vendor and model name in tgtd so that timeout is set to 180 by udev rule

### DIFF
--- a/usr/sbc.c
+++ b/usr/sbc.c
@@ -735,7 +735,7 @@ static tgtadm_err sbc_lu_init(struct scsi_lu *lu)
 	if (spc_lu_init(lu))
 		return TGTADM_NOMEM;
 
-	strncpy(lu->attrs.product_id, "VIRTUAL-DISK", sizeof(lu->attrs.product_id));
+	strncpy(lu->attrs.product_id, "Virtual disk", sizeof(lu->attrs.product_id));
 	lu->attrs.version_desc[0] = 0x04C0; /* SBC-3 no version claimed */
 	lu->attrs.version_desc[1] = 0x0960; /* iSCSI */
 	lu->attrs.version_desc[2] = 0x0300; /* SPC-3 */

--- a/usr/spc.c
+++ b/usr/spc.c
@@ -2073,7 +2073,7 @@ int spc_lu_init(struct scsi_lu *lu)
 	snprintf(lu->attrs.product_rev, sizeof(lu->attrs.product_rev),
 		 "%s", "0001");
 	snprintf(lu->attrs.scsi_id, sizeof(lu->attrs.scsi_id),
-		 "IET     %04x%04" PRIx64, tgt->tid, lu->lun);
+		 "VMware     %04x%04" PRIx64, tgt->tid, lu->lun);
 	snprintf(lu->attrs.scsi_sn, sizeof(lu->attrs.scsi_sn),
 		 "beaf%d%" PRIu64, tgt->tid, lu->lun);
 	lu->attrs.numeric_id = tgt->tid;

--- a/usr/tgtd.h
+++ b/usr/tgtd.h
@@ -28,7 +28,7 @@ struct concat_buf;
 #define BLOCK_DESCRIPTOR_LEN	8
 #define VERSION_DESCRIPTOR_LEN	8
 
-#define VENDOR_ID	"IET"
+#define VENDOR_ID	"VMware"
 
 #define _TAB1 "    "
 #define _TAB2 _TAB1 _TAB1


### PR DESCRIPTION
Change the default vendor and model name from "IET" to "VMware" and from "VIRTUAL-DISK" to "Virtual Disk" respectively in tgtd code. This to make sure that udev rule being injected by Vmware, get the same disk property at Cloud. Tested with RedHat, we need to test it with Ubuntu and Window to see that changes are not causing any regression. 

/* On Linux, udev rules expects following */ 
#cat /lib/udev/rules.d/99-vmware-scsi-udev.rules 
ACTION=="add", SUBSYSTEMS=="scsi", **ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*"**, RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"


/* Before changes, query to cloud disk  was returning following */
[root@localhost ~]# udevadm info -a  /dev/sda | grep -iE "VENDOR|MODEL" 
    ATTRS{model}=="VIRTUAL-DISK    "
    ATTRS{vendor}=="IET     "

/* After changes, we get following device properties */ 
[root@localhost ~]# udevadm info -a  /dev/sda | grep -iE "VENDOR|MODEL" 
    ATTRS{model}=="Virtual_disk    "
    ATTRS{vendor}=="Vmware     "
